### PR TITLE
Upgraded HPPC to version 0.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <dependency>
       <groupId>com.carrotsearch</groupId>
       <artifactId>hppc</artifactId>
-      <version>0.6.1</version>
+      <version>0.7.1</version>
     </dependency>
     <dependency>
       <groupId>org.tukaani</groupId>

--- a/src/main/java/edu/emory/clir/clearnlp/collection/map/CharCharHashMap.java
+++ b/src/main/java/edu/emory/clir/clearnlp/collection/map/CharCharHashMap.java
@@ -22,8 +22,9 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 
-import com.carrotsearch.hppc.CharCharOpenHashMap;
+import com.carrotsearch.hppc.cursors.CharCharCursor;
 
 import edu.emory.clir.clearnlp.collection.pair.CharCharPair;
 
@@ -35,23 +36,23 @@ public class CharCharHashMap implements Serializable, Iterable<CharCharPair>
 {
 	private static final long serialVersionUID = -1072021691426162355L;
 	static public char DEFAULT_VALUE = '\u0000';
-	private CharCharOpenHashMap g_map;
+	private com.carrotsearch.hppc.CharCharHashMap g_map;
 	
 	public CharCharHashMap()
 	{
-		g_map = new CharCharOpenHashMap();
+		g_map = new com.carrotsearch.hppc.CharCharHashMap();
 	}
 	
 	public CharCharHashMap(int initialCapacity)
 	{
-		g_map = new CharCharOpenHashMap(initialCapacity);
+		g_map = new com.carrotsearch.hppc.CharCharHashMap(initialCapacity);
 	}
 	
 	@SuppressWarnings("unchecked")
 	private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException
 	{
 		List<CharCharPair> list = (List<CharCharPair>)in.readObject();
-		g_map = new CharCharOpenHashMap(list.size());
+		g_map = new com.carrotsearch.hppc.CharCharHashMap(list.size());
 		putAll(list);
 	}
 
@@ -119,32 +120,27 @@ public class CharCharHashMap implements Serializable, Iterable<CharCharPair>
 	{
 		Iterator<CharCharPair> it = new Iterator<CharCharPair>()
 		{
-			private final int key_size = g_map.keys.length;
-			private int current_index  = 0;
+			private final Iterator<CharCharCursor> g_iter =  g_map.iterator();
 			
 			@Override
 			public boolean hasNext()
 			{
-				for (; current_index < key_size; current_index++)
-				{
-					if (g_map.allocated[current_index])
-						return true;
-				}
-				
-				return false;
+				return g_iter.hasNext();
 			}
 			
 			@Override
 			public CharCharPair next()
 			{
-				if (current_index < key_size)
-				{
-					CharCharPair p = new CharCharPair(g_map.keys[current_index], g_map.values[current_index]);
-					current_index++;
-					return p;
+				CharCharPair p = null;
+				try{
+					CharCharCursor cursor = g_iter.next();
+					p = new CharCharPair(cursor.key, cursor.value);
 				}
-				
-				return null;
+				catch (NoSuchElementException e)
+				{
+					
+				}
+				return p;
 			}
 			
 			@Override

--- a/src/main/java/edu/emory/clir/clearnlp/collection/map/CharIntHashMap.java
+++ b/src/main/java/edu/emory/clir/clearnlp/collection/map/CharIntHashMap.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *	 http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,8 +22,9 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 
-import com.carrotsearch.hppc.CharIntOpenHashMap;
+import com.carrotsearch.hppc.cursors.CharIntCursor;
 
 import edu.emory.clir.clearnlp.collection.pair.CharIntPair;
 
@@ -35,23 +36,23 @@ public class CharIntHashMap implements Serializable, Iterable<CharIntPair>
 {
 	private static final long serialVersionUID = -1072021691426162355L;
 	static public char DEFAULT_VALUE = '\u0000';
-	private CharIntOpenHashMap g_map;
+	private com.carrotsearch.hppc.CharIntHashMap g_map;
 	
 	public CharIntHashMap()
 	{
-		g_map = new CharIntOpenHashMap();
+		g_map = new com.carrotsearch.hppc.CharIntHashMap();
 	}
 	
 	public CharIntHashMap(int initialCapacity)
 	{
-		g_map = new CharIntOpenHashMap(initialCapacity);
+		g_map = new com.carrotsearch.hppc.CharIntHashMap(initialCapacity);
 	}
 	
 	@SuppressWarnings("unchecked")
 	private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException
 	{
 		List<CharIntPair> list = (List<CharIntPair>)in.readObject();
-		g_map = new CharIntOpenHashMap(list.size());
+		g_map = new com.carrotsearch.hppc.CharIntHashMap(list.size());
 		putAll(list);
 	}
 
@@ -119,32 +120,27 @@ public class CharIntHashMap implements Serializable, Iterable<CharIntPair>
 	{
 		Iterator<CharIntPair> it = new Iterator<CharIntPair>()
 		{
-			private final int key_size = g_map.keys.length;
-			private int current_index  = 0;
+			private final Iterator<CharIntCursor> g_iter =  g_map.iterator();
 			
 			@Override
 			public boolean hasNext()
 			{
-				for (; current_index < key_size; current_index++)
-				{
-					if (g_map.allocated[current_index])
-						return true;
-				}
-				
-				return false;
+				return g_iter.hasNext();
 			}
 			
 			@Override
 			public CharIntPair next()
 			{
-				if (current_index < key_size)
-				{
-					CharIntPair p = new CharIntPair(g_map.keys[current_index], g_map.values[current_index]);
-					current_index++;
-					return p;
+				CharIntPair p = null;
+				try{
+					CharIntCursor cursor = g_iter.next();
+					p = new CharIntPair(cursor.key, cursor.value);
 				}
-				
-				return null;
+				catch (NoSuchElementException e)
+				{
+					
+				}
+				return p;
 			}
 			
 			@Override

--- a/src/main/java/edu/emory/clir/clearnlp/collection/map/IntDoubleHashMap.java
+++ b/src/main/java/edu/emory/clir/clearnlp/collection/map/IntDoubleHashMap.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *	 http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,8 +22,9 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 
-import com.carrotsearch.hppc.IntDoubleOpenHashMap;
+import com.carrotsearch.hppc.cursors.IntDoubleCursor;
 
 import edu.emory.clir.clearnlp.collection.pair.DoubleIntPair;
 
@@ -34,23 +35,23 @@ import edu.emory.clir.clearnlp.collection.pair.DoubleIntPair;
 public class IntDoubleHashMap implements Serializable, Iterable<DoubleIntPair>
 {
 	private static final long serialVersionUID = 5327212904932776361L;
-	private IntDoubleOpenHashMap g_map;
+	private com.carrotsearch.hppc.IntDoubleHashMap g_map;
 	
 	public IntDoubleHashMap()
 	{
-		g_map = new IntDoubleOpenHashMap();
+		g_map = new com.carrotsearch.hppc.IntDoubleHashMap();
 	}
 	
 	public IntDoubleHashMap(int initialCapacity)
 	{
-		g_map = new IntDoubleOpenHashMap(initialCapacity);
+		g_map = new com.carrotsearch.hppc.IntDoubleHashMap(initialCapacity);
 	}
 	
 	@SuppressWarnings("unchecked")
 	private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException
 	{
 		List<DoubleIntPair> list = (List<DoubleIntPair>)in.readObject();
-		g_map = new IntDoubleOpenHashMap(list.size());
+		g_map = new com.carrotsearch.hppc.IntDoubleHashMap(list.size());
 		putAll(list);
 	}
 
@@ -118,32 +119,27 @@ public class IntDoubleHashMap implements Serializable, Iterable<DoubleIntPair>
 	{
 		Iterator<DoubleIntPair> it = new Iterator<DoubleIntPair>()
 		{
-			private final int key_size = g_map.keys.length;
-			private int current_index  = 0;
+			private final Iterator<IntDoubleCursor> g_iter =  g_map.iterator();
 			
 			@Override
 			public boolean hasNext()
 			{
-				for (; current_index < key_size; current_index++)
-				{
-					if (g_map.allocated[current_index])
-						return true;
-				}
-				
-				return false;
+				return g_iter.hasNext();
 			}
 			
 			@Override
 			public DoubleIntPair next()
 			{
-				if (current_index < key_size)
-				{
-					DoubleIntPair p = new DoubleIntPair(g_map.values[current_index], g_map.keys[current_index]);
-					current_index++;
-					return p;
+				DoubleIntPair p = null;
+				try{
+					IntDoubleCursor cursor = g_iter.next();
+					p = new DoubleIntPair(cursor.value, cursor.key);
 				}
-				
-				return null;
+				catch (NoSuchElementException e)
+				{
+					
+				}
+				return p;
 			}
 			
 			@Override

--- a/src/main/java/edu/emory/clir/clearnlp/collection/map/IntIntHashMap.java
+++ b/src/main/java/edu/emory/clir/clearnlp/collection/map/IntIntHashMap.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *	 http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,8 +22,9 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 
-import com.carrotsearch.hppc.IntIntOpenHashMap;
+import com.carrotsearch.hppc.cursors.IntIntCursor;
 
 import edu.emory.clir.clearnlp.collection.pair.IntIntPair;
 
@@ -34,23 +35,23 @@ import edu.emory.clir.clearnlp.collection.pair.IntIntPair;
 public class IntIntHashMap implements Serializable, Iterable<IntIntPair>
 {
 	private static final long serialVersionUID = 5327212904932776361L;
-	private IntIntOpenHashMap g_map;
+	private com.carrotsearch.hppc.IntIntHashMap g_map;
 	
 	public IntIntHashMap()
 	{
-		g_map = new IntIntOpenHashMap();
+		g_map = new com.carrotsearch.hppc.IntIntHashMap();
 	}
 	
 	public IntIntHashMap(int initialCapacity)
 	{
-		g_map = new IntIntOpenHashMap(initialCapacity);
+		g_map = new com.carrotsearch.hppc.IntIntHashMap(initialCapacity);
 	}
 	
 	@SuppressWarnings("unchecked")
 	private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException
 	{
 		List<IntIntPair> list = (List<IntIntPair>)in.readObject();
-		g_map = new IntIntOpenHashMap(list.size());
+		g_map = new com.carrotsearch.hppc.IntIntHashMap(list.size());
 		putAll(list);
 	}
 
@@ -130,32 +131,27 @@ public class IntIntHashMap implements Serializable, Iterable<IntIntPair>
 	{
 		Iterator<IntIntPair> it = new Iterator<IntIntPair>()
 		{
-			private final int key_size = g_map.keys.length;
-			private int current_index  = 0;
+			private final Iterator<IntIntCursor> g_iter =  g_map.iterator();
 			
 			@Override
 			public boolean hasNext()
 			{
-				for (; current_index < key_size; current_index++)
-				{
-					if (g_map.allocated[current_index])
-						return true;
-				}
-				
-				return false;
+				return g_iter.hasNext();
 			}
 			
 			@Override
 			public IntIntPair next()
 			{
-				if (current_index < key_size)
-				{
-					IntIntPair p = new IntIntPair(g_map.values[current_index], g_map.keys[current_index]);
-					current_index++;
-					return p;
+				IntIntPair p = null;
+				try{
+					IntIntCursor cursor = g_iter.next();
+					p = new IntIntPair(cursor.value, cursor.key);
 				}
-				
-				return null;
+				catch (NoSuchElementException e)
+				{
+					
+				}
+				return p;
 			}
 			
 			@Override

--- a/src/main/java/edu/emory/clir/clearnlp/collection/map/ObjectDoubleHashMap.java
+++ b/src/main/java/edu/emory/clir/clearnlp/collection/map/ObjectDoubleHashMap.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *	 http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,8 +22,9 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 
-import com.carrotsearch.hppc.ObjectDoubleOpenHashMap;
+import com.carrotsearch.hppc.cursors.ObjectDoubleCursor;
 
 import edu.emory.clir.clearnlp.collection.pair.ObjectDoublePair;
 
@@ -34,23 +35,23 @@ import edu.emory.clir.clearnlp.collection.pair.ObjectDoublePair;
 public class ObjectDoubleHashMap<T> implements Serializable, Iterable<ObjectDoublePair<T>>
 {
 	private static final long serialVersionUID = -869739556140492570L;
-	private ObjectDoubleOpenHashMap<T> g_map;
+	private com.carrotsearch.hppc.ObjectDoubleHashMap<T> g_map;
 	
 	public ObjectDoubleHashMap()
 	{
-		g_map = new ObjectDoubleOpenHashMap<T>();
+		g_map = new com.carrotsearch.hppc.ObjectDoubleHashMap<T>();
 	}
 	
 	public ObjectDoubleHashMap(int initialCapacity)
 	{
-		g_map = new ObjectDoubleOpenHashMap<T>(initialCapacity);
+		g_map = new com.carrotsearch.hppc.ObjectDoubleHashMap<T>(initialCapacity);
 	}
 	
 	@SuppressWarnings("unchecked")
 	private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException
 	{
 		List<ObjectDoublePair<T>> list = (List<ObjectDoublePair<T>>)in.readObject();
-		g_map = new ObjectDoubleOpenHashMap<T>(list.size());
+		g_map = new com.carrotsearch.hppc.ObjectDoubleHashMap<T>(list.size());
 		put(list);
 	}
 
@@ -138,32 +139,27 @@ public class ObjectDoubleHashMap<T> implements Serializable, Iterable<ObjectDoub
 	{
 		Iterator<ObjectDoublePair<T>> it = new Iterator<ObjectDoublePair<T>>()
 		{
-			private final int key_size = g_map.keys.length;
-			private int current_index  = 0;
+			private final Iterator<ObjectDoubleCursor<T>> g_iter = g_map.iterator();
 			
 			@Override
 			public boolean hasNext()
 			{
-				for (; current_index < key_size; current_index++)
-				{
-					if (g_map.allocated[current_index])
-						return true;
-				}
-				
-				return false;
+				return g_iter.hasNext();
 			}
 			
 			@Override
 			public ObjectDoublePair<T> next()
 			{
-				if (current_index < key_size)
-				{
-					ObjectDoublePair<T> p = new ObjectDoublePair<T>(g_map.keys[current_index], g_map.values[current_index]);
-					current_index++;
-					return p;
+				ObjectDoublePair<T> p = null;
+				try {
+					ObjectDoubleCursor<T> cursor = g_iter.next();
+					p = new ObjectDoublePair<T>(cursor.key, cursor.value);
 				}
-				
-				return null;
+				catch (NoSuchElementException e)
+				{
+					
+				}
+				return p;
 			}
 			
 			@Override

--- a/src/main/java/edu/emory/clir/clearnlp/collection/set/CharHashSet.java
+++ b/src/main/java/edu/emory/clir/clearnlp/collection/set/CharHashSet.java
@@ -20,13 +20,11 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
-import com.carrotsearch.hppc.CharOpenHashSet;
-
 /**
  * @since 3.0.0
  * @author Jinho D. Choi ({@code jinho.choi@emory.edu})
  */
-public class CharHashSet extends CharOpenHashSet implements Serializable
+public class CharHashSet extends com.carrotsearch.hppc.CharHashSet implements Serializable
 {
 	private static final long serialVersionUID = -3796053685010557911L;
 	
@@ -54,11 +52,5 @@ public class CharHashSet extends CharOpenHashSet implements Serializable
 	private void writeObject(ObjectOutputStream o) throws IOException
 	{
 		o.writeObject(toArray());
-	}
-	
-	public void addAll(char[] array)
-	{
-		for (char item : array)
-			add(item);
 	}
 }

--- a/src/main/java/edu/emory/clir/clearnlp/collection/set/IntHashSet.java
+++ b/src/main/java/edu/emory/clir/clearnlp/collection/set/IntHashSet.java
@@ -20,13 +20,11 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
-import com.carrotsearch.hppc.IntOpenHashSet;
-
 /**
  * @since 3.0.0
  * @author Jinho D. Choi ({@code jinho.choi@emory.edu})
  */
-public class IntHashSet extends IntOpenHashSet implements Serializable
+public class IntHashSet extends com.carrotsearch.hppc.IntHashSet implements Serializable
 {
 	private static final long serialVersionUID = 8220093021280571821L;
 	
@@ -48,12 +46,6 @@ public class IntHashSet extends IntOpenHashSet implements Serializable
 	private void writeObject(ObjectOutputStream o) throws IOException
 	{
 		o.writeObject(toArray());
-	}
-	
-	public void addAll(int[] array)
-	{
-		for (int item : array)
-			add(item);
 	}
 	
 	public void addAll(IntHashSet set)

--- a/src/main/java/edu/emory/clir/clearnlp/constituent/CTTree.java
+++ b/src/main/java/edu/emory/clir/clearnlp/constituent/CTTree.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import com.carrotsearch.hppc.IntIntOpenHashMap;
+import com.carrotsearch.hppc.IntIntHashMap;
 
 import edu.emory.clir.clearnlp.collection.map.IntObjectHashMap;
 import edu.emory.clir.clearnlp.collection.pair.ObjectIntPair;
@@ -273,7 +273,7 @@ public class CTTree
 		List<ObjectIntPair<List<CTNode>>> ps = mOrg.toList();
 		Collections.sort(ps);
 		
-		IntIntOpenHashMap mNew = new IntIntOpenHashMap();
+		IntIntHashMap mNew = new IntIntHashMap();
 		int coIndex = 1, last, i;
 		boolean isAnteFound;
 		List<CTNode> list;
@@ -352,7 +352,7 @@ public class CTTree
 	}
 	
 	/** Called by {@link #normalizeIndices()}. */
-	private void remapGapIndices(IntIntOpenHashMap map, int[] lastIndex, CTNode curr)
+	private void remapGapIndices(IntIntHashMap map, int[] lastIndex, CTNode curr)
 	{
 		int gapIndex = curr.getGappingRelationIndex();
 		

--- a/src/test/java/edu/emory/clir/clearnlp/collection/map/ObjectDoubleHashMapTest.java
+++ b/src/test/java/edu/emory/clir/clearnlp/collection/map/ObjectDoubleHashMapTest.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
@@ -58,7 +59,9 @@ public class ObjectDoubleHashMapTest
 		for (ObjectDoublePair<String> item : items)
 			assertEquals(item.d, map.get(item.o), 0);
 		
-		assertEquals("[(C,3.5), (B,2.5), (A,1.5)]", map.toList().toString());
+		List<ObjectDoublePair<String>> mapElements = map.toList();
+		Collections.sort(mapElements);
+		assertEquals("[(A,1.5), (B,2.5), (C,3.5)]", mapElements.toString());
 	}
 	
 	@Test

--- a/src/test/java/edu/emory/clir/clearnlp/collection/map/ObjectIntHashMapTest.java
+++ b/src/test/java/edu/emory/clir/clearnlp/collection/map/ObjectIntHashMapTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *	 http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
@@ -58,7 +59,9 @@ public class ObjectIntHashMapTest
 		for (ObjectIntPair<String> item : items)
 			assertEquals(item.i, map.get(item.o));
 		
-		assertEquals("[(C,3), (B,2), (A,1)]", map.toList().toString());
+		List<ObjectIntPair<String>> mapElements = map.toList();
+		Collections.sort(mapElements);
+		assertEquals("[(A,1), (B,2), (C,3)]", mapElements.toString());
 	}
 	
 	@Test


### PR DESCRIPTION
This is an upgrade to HPPC version 0.7.1 for compatibility with projects that depend on [carrot2 >= 3.10.0](http://mvnrepository.com/artifact/org.carrot2/carrot2/3.10.0).

Relevant API-breaking changes:
- [HPPC-145](http://issues.carrot2.org/browse/HPPC-145): Removed any "Open" infix from all classes.
- [HPPC-97](http://issues.carrot2.org/browse/HPPC-97): Use unallocated slot marker key instead of an explicit allocation table for hash containers.

see [hppc/changes.txt](https://github.com/carrotsearch/hppc/blob/master/CHANGES.txt)
